### PR TITLE
17 enable setting rng seed

### DIFF
--- a/components/arena_grid.gd
+++ b/components/arena_grid.gd
@@ -42,11 +42,11 @@ func get_first_empty_tile() -> Vector2i:
 
 func get_random_empty_tile() -> Vector2i:
 	var keys := tiles.keys()
-	var tile: Vector2i = keys.pick_random()
+	var tile: Vector2i = RNG.array_pick_random(keys)
 	
 	while is_tile_occupied(tile):
 		keys.erase(tile)
-		tile = keys.pick_random()
+		tile = RNG.array_pick_random(keys)
 
 	return tile
 

--- a/global/rng.gd
+++ b/global/rng.gd
@@ -12,10 +12,13 @@ func initialize() -> void:
 	instance.randomize()
 
 
-# TODO when adding saving add state
 func set_seed(old_seed: int) -> void:
 	instance = RandomNumberGenerator.new()
 	instance.seed = old_seed
+
+
+func set_state(old_state: int) -> void:
+	instance.state = old_state
 
 
 func array_pick_random(array: Array) -> Variant:
@@ -27,7 +30,7 @@ func array_pick_random(array: Array) -> Variant:
 func array_shuffle(array: Array) -> void:
 	if array.size() < 2: return
 
-	for i in range(array.size()- 1, 0, -1):
+	for i in range(array.size() - 1, 0, -1):
 		var j := instance.randi() % (i + 1)
 		var tmp = array[j]
 		array[j] = array[i]

--- a/resources/run_stats.gd
+++ b/resources/run_stats.gd
@@ -9,9 +9,13 @@ const STARTING_VIAL_COUNT := 3
 @export var inventory: Dictionary[ItemConfig.KEYS, int]
 @export var artifacts: Array[Artifact]
 @export var party: Array[UnitStats]
-@export var max_party_size := STARTING_PARTY_SIZE
 @export var vials: Array[Vial]
+@export_category("Limits")
+@export var max_party_size := STARTING_PARTY_SIZE
 @export var max_vial_count := STARTING_VIAL_COUNT
+@export_category("Run Data")
+@export var rng_seed: int
+@export var rng_state: int
 
 
 func add_item_to_inventory(key: ItemConfig.KEYS, count: int) -> void:	

--- a/scenes/main_menu/main_menu.gd
+++ b/scenes/main_menu/main_menu.gd
@@ -32,6 +32,7 @@ func _on_continue_button_pressed() -> void:
 
 func _on_new_run_button_pressed() -> void:
 	var run_stats = RunStats.new()
+	run_stats.rng_seed = RNG.instance.seed
 
 	if rng_seed_line_edit.text:
 		if int(rng_seed_line_edit.text) == 0:

--- a/scenes/main_menu/main_menu.gd
+++ b/scenes/main_menu/main_menu.gd
@@ -10,7 +10,7 @@ const PARTY_SELECT = preload("res://scenes/party_select/party_select.tscn")
 @onready var setting_button: Button = %SettingButton
 @onready var exit_button: Button = %ExitButton
 @onready var settings_ui: Control = %SettingsUI
-
+@onready var rng_seed_line_edit: LineEdit = $RNGSeedTextEdit
 @onready var unit: Unit = $Unit
 
 
@@ -31,7 +31,16 @@ func _on_continue_button_pressed() -> void:
 
 
 func _on_new_run_button_pressed() -> void:
-	SceneChanger.change_scene(PARTY_SELECT)
+	var run_stats = RunStats.new()
+
+	if rng_seed_line_edit.text:
+		if int(rng_seed_line_edit.text) == 0:
+			RNG.set_seed(hash(rng_seed_line_edit.text))
+			run_stats.rng_seed = hash(rng_seed_line_edit.text)
+		else:
+			RNG.set_seed(int(rng_seed_line_edit.text))
+			run_stats.rng_seed = int(rng_seed_line_edit.text)
+	SceneChanger.change_scene(PARTY_SELECT, run_stats)
 
 
 func _on_setting_button_pressed() -> void:

--- a/scenes/main_menu/main_menu.tscn
+++ b/scenes/main_menu/main_menu.tscn
@@ -183,12 +183,8 @@ layout_mode = 1
 [node name="RNGSeedTextEdit" type="LineEdit" parent="."]
 custom_minimum_size = Vector2(125, 20)
 layout_mode = 1
-anchors_preset = 2
-anchor_top = 1.0
-anchor_bottom = 1.0
-offset_top = -19.0
-offset_right = 48.0
-grow_vertical = 0
+offset_right = 125.0
+offset_bottom = 20.0
 placeholder_text = "Set Seed"
 alignment = 1
 max_length = 19

--- a/scenes/main_menu/main_menu.tscn
+++ b/scenes/main_menu/main_menu.tscn
@@ -179,3 +179,19 @@ texture = ExtResource("4_uqeha")
 [node name="SettingsUI" parent="." instance=ExtResource("5_wem23")]
 unique_name_in_owner = true
 layout_mode = 1
+
+[node name="RNGSeedTextEdit" type="LineEdit" parent="."]
+custom_minimum_size = Vector2(125, 20)
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_top = -19.0
+offset_right = 48.0
+grow_vertical = 0
+placeholder_text = "Set Seed"
+alignment = 1
+max_length = 19
+expand_to_text_length = true
+emoji_menu_enabled = false
+virtual_keyboard_type = 2

--- a/scenes/map/map_generator.gd
+++ b/scenes/map/map_generator.gd
@@ -84,7 +84,7 @@ func _get_random_starting_points() -> Array[int]:
 		indexes = []
 
 		for i in MAX_STARTS:
-			var starting_point := randi_range(0, MAP_HEIGHT - 1)
+			var starting_point := RNG.instance.randi_range(0, MAP_HEIGHT - 1)
 			if not indexes.has(starting_point):
 				unique_points += 1
 
@@ -98,7 +98,7 @@ func _setup_connection(row: int, column: int) -> int:
 	var current_room := map_data[row][column] as Room
 
 	while not next_room or _would_cross_existing_path(row, column, next_room):
-		var random_column := clampi(randi_range(column -1, column + 1), 0, MAP_HEIGHT - 1)
+		var random_column := clampi(RNG.instance.randi_range(column -1, column + 1), 0, MAP_HEIGHT - 1)
 		next_room = map_data[row + 1][random_column]
 
 	current_room.next_rooms.append(next_room)
@@ -236,7 +236,7 @@ func _set_room_randomly(room_to_set: Room) -> void:
 
 
 func _get_random_room_type_by_weight() -> Room.TYPE:
-	var roll := randf_range(0.0, random_room_type_total_weight)
+	var roll := RNG.instance.randf_range(0.0, random_room_type_total_weight)
 
 	for type in random_room_type_weights:
 		if random_room_type_weights[type] > roll:

--- a/scenes/map/map_room.gd
+++ b/scenes/map/map_room.gd
@@ -62,7 +62,7 @@ func set_available(value: bool) -> void:
 		# that uses any colour causing it to overwrite the alpha, so I can't fade out unavailable rooms
 		available_sprite.show()
 		disabled_sprite.hide()
-		await get_tree().create_timer(RNG.instance.randf_range(0.0, .4)).timeout
+		await get_tree().create_timer(randf_range(0.0, .4)).timeout
 		animation_player.play("available")
 	else:
 		available_sprite.hide()

--- a/scenes/party_select/party_select.gd
+++ b/scenes/party_select/party_select.gd
@@ -37,10 +37,12 @@ const OPTION_COUNT := 3
 
 
 func _ready() -> void:
+	run_stats = SceneChanger.get_run_stats()
+
 	if not run_stats:
 		run_stats = RunStats.new()
-		_set_up_managers()
 
+	_set_up_managers()
 	_set_up_connections()
 	_generate_options()
 
@@ -92,7 +94,7 @@ func _generate_items() -> Array:
 	var item_contents := []
 
 	for item in OPTION_COUNT:
-			var chance := randf_range(0.0, 1.0)
+			var chance := RNG.instance.randf_range(0.0, 1.0)
 
 			# TODO Maybe this should be a weighted table for more granular control
 			if chance <= vial_odds:

--- a/scenes/party_select/party_select.tscn
+++ b/scenes/party_select/party_select.tscn
@@ -162,7 +162,5 @@ offset_left = -150.0
 offset_top = -164.0
 offset_right = 150.0
 offset_bottom = 66.0
-grow_horizontal = 2
-grow_vertical = 2
 
 [node name="Tooltip" parent="." instance=ExtResource("28_227sm")]

--- a/scenes/run/run.gd
+++ b/scenes/run/run.gd
@@ -21,6 +21,7 @@ const KILN_SCNE := preload("res://scenes/kiln/kiln.tscn")
 @onready var settings_button: TextureButton = %SettingsButton
 @onready var settings_ui: Control = %SettingsUI
 @onready var unit_fill_ui: UnitFillUI = %UnitFillUI
+@onready var rng_seed_label: Label = %RNGSeedLabel
 
 @onready var current_view: Node = $CurrentView
 @onready var map: Node2D = $Map
@@ -111,6 +112,7 @@ func _set_up_top_bar() -> void:
 	inventory_ui.inventory_manager = inventory_manager
 	inventory_ui.party_manager = party_manager
 	unit_fill_ui.party_manager = party_manager
+	rng_seed_label.text = str(run_stats.rng_seed)
 
 
 func _change_view(scene: PackedScene) -> Node:

--- a/scenes/run/run.tscn
+++ b/scenes/run/run.tscn
@@ -144,6 +144,16 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "Shop"
 
+[node name="RNGSeedLabel" type="Label" parent="TopBar"]
+unique_name_in_owner = true
+offset_left = 521.0
+offset_top = 28.0
+offset_right = 634.0
+offset_bottom = 39.0
+theme_override_colors/font_color = Color(0.241156, 0.241156, 0.241156, 1)
+text = "12345678987654321234"
+horizontal_alignment = 2
+
 [node name="UI" type="CanvasLayer" parent="."]
 layer = 5
 


### PR DESCRIPTION
CLOSES 17

Added line edit to main menu to set a seed for a new run
Added label on run scene to show the current seed so it can be reused in future runs
Added rng_seed and rng_state to run stats so rng instances can be recreated

Fixed multiple instance where I forgot to use the rng instance and removed some uses for ui/ux elements where the randomness does not matter